### PR TITLE
Livy2 Server

### DIFF
--- a/HDP_Scripts/blueprints/cerebri-sanza-spark.blueprint
+++ b/HDP_Scripts/blueprints/cerebri-sanza-spark.blueprint
@@ -45,6 +45,9 @@
           "name": "HBASE_CLIENT"
         },
         {
+          "name": "LIVY2_SERVER"
+        },
+        {
           "name": "HIVE_CLIENT"
         },
         {


### PR DESCRIPTION
Adding service name for Livy2 server in the Ambari node definition of the sanza-spark blueprint for Cloudbreak